### PR TITLE
fix: keep enemy POV across rapid kills

### DIFF
--- a/src/ui/match/video/sequences/build-players-event-sequences.ts
+++ b/src/ui/match/video/sequences/build-players-event-sequences.ts
@@ -96,6 +96,13 @@ export function buildPlayersEventSequences({
       const areSequencesOverlapping = previousSequence.endTick + ticksRequiredBetweenTwoSequences >= sequenceStartTick;
       if (areSequencesOverlapping) {
         previousSequence.endTick = sequenceEndTick;
+        if (perspective === Perspective.Enemy) {
+          previousSequence.cameras.push({
+            tick: sequenceStartTick,
+            playerSteamId: steamIdToFocus,
+            playerName: match.players.find((player) => player.steamId === steamIdToFocus)?.name ?? '',
+          });
+        }
         continue;
       }
     }


### PR DESCRIPTION
## Summary
- keep enemy perspective when merging kill sequences by appending camera focus for each kill
- test enemy POV camera handling with rapid kills

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5853cbffc832ba984ffa91c586b57