### PR TITLE
feat: track sequence progress during recording

### DIFF
--- a/src/cli/commands/video-command.ts
+++ b/src/cli/commands/video-command.ts
@@ -168,6 +168,9 @@ export class VideoCommand extends Command {
         onMoveFilesStart: () => {
           console.log('Moving files...');
         },
+        onSequenceRecordStart: (number) => {
+          console.log(`Recording sequence ${number}...`);
+        },
         onSequenceStart: (number) => {
           console.log(`Converting sequence ${number}...`);
         },

--- a/src/server/game-client-message-name.ts
+++ b/src/server/game-client-message-name.ts
@@ -1,10 +1,12 @@
 // Message names sent from the game process to the WebSocket server.
 export const GameClientMessageName = {
   Status: 'status',
+  SequenceStart: 'sequence-start',
 } as const;
 
 export type GameClientMessageName = (typeof GameClientMessageName)[keyof typeof GameClientMessageName];
 
 export interface GameClientMessagePayload {
   [GameClientMessageName.Status]: 'ok';
+  [GameClientMessageName.SequenceStart]: number;
 }

--- a/src/server/video-queue.ts
+++ b/src/server/video-queue.ts
@@ -126,6 +126,12 @@ class VideoQueue {
         onMoveFilesStart: () => {
           this.updateCurrentVideoAnNotifyRendererProcess({ status: VideoStatus.MovingFiles });
         },
+        onSequenceRecordStart: (sequenceNumber) => {
+          this.updateCurrentVideoAnNotifyRendererProcess({
+            status: VideoStatus.Recording,
+            currentSequence: sequenceNumber,
+          });
+        },
         onSequenceStart: (sequenceNumber) => {
           this.updateCurrentVideoAnNotifyRendererProcess({
             status: VideoStatus.Converting,

--- a/src/ui/videos/video-entry.tsx
+++ b/src/ui/videos/video-entry.tsx
@@ -59,12 +59,17 @@ function getStatusMessage(video: Video) {
           <Trans>Waiting…</Trans>
         </p>
       );
-    case VideoStatus.Recording:
+    case VideoStatus.Recording: {
+      const number = video.currentSequence;
+      const sequenceCount = video.sequences.length;
       return (
         <p>
-          <Trans>In-game recording in progress…</Trans>
+          <Trans>
+            Recording sequence {number} / {sequenceCount}…
+          </Trans>
         </p>
       );
+    }
     case VideoStatus.MovingFiles:
       return (
         <p>


### PR DESCRIPTION
## Summary
- forward sequence-start messages from game to server and update video progress
- listen for sequence start during recording and conversion phases
- display current sequence while recording in video entry

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5c08e8ae4832bb0e5d2301065f439