### PR TITLE
Enable match navigation from player graphs

### DIFF
--- a/src/common/types/charts/player-charts-data.ts
+++ b/src/common/types/charts/player-charts-data.ts
@@ -4,6 +4,7 @@ export type PlayerChartsData = {
   averageDamagePerRound: number;
   clutchWonPercentage: number;
   matchDate: string;
+  matchChecksum: string;
 };
 
-export type PlayerChartDataField = keyof Omit<PlayerChartsData, 'matchDate'>;
+export type PlayerChartDataField = keyof Omit<PlayerChartsData, 'matchDate' | 'matchChecksum'>;

--- a/src/node/database/player/fetch-player-charts-data.ts
+++ b/src/node/database/player/fetch-player-charts-data.ts
@@ -10,6 +10,7 @@ export async function fetchPlayerChartsData(steamId: string, filters: MatchFilte
       'headshot_percentage as headshotPercentage',
       'average_damage_per_round as averageDamagePerRound',
       'kill_death_ratio as killDeathRatio',
+      'players.match_checksum as matchChecksum',
     ])
     .leftJoin('matches', 'matches.checksum', 'players.match_checksum')
     .select(sql<string>`to_char(matches.date, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`.as('matchDate'))
@@ -24,7 +25,7 @@ export async function fetchPlayerChartsData(steamId: string, filters: MatchFilte
       ),
     ])
     .where('steam_id', '=', steamId)
-    .groupBy(['headshotPercentage', 'averageDamagePerRound', 'killDeathRatio', 'matches.date'])
+    .groupBy(['headshotPercentage', 'averageDamagePerRound', 'killDeathRatio', 'matchChecksum', 'matches.date'])
     .orderBy('date', 'asc');
 
   query = applyMatchFilters(query, filters);

--- a/src/ui/player/charts/average-damage-per-round-chart.tsx
+++ b/src/ui/player/charts/average-damage-per-round-chart.tsx
@@ -13,7 +13,7 @@ type Props = {
 };
 
 export function AverageDamagePerRoundChart({ axis }: Props) {
-  const { chartsData, matches } = usePlayer();
+  const { chartsData } = usePlayer();
   const { t } = useLingui();
   const data: [string, number][] = buildAveragePlayerChartData({
     field: 'averageDamagePerRound',
@@ -55,7 +55,6 @@ export function AverageDamagePerRoundChart({ axis }: Props) {
   useOpenMatchOnPointDoubleClick({
     axis,
     chartsData,
-    matches,
     getChartInstance,
   });
 

--- a/src/ui/player/charts/clutch-won-percentage-chart.tsx
+++ b/src/ui/player/charts/clutch-won-percentage-chart.tsx
@@ -12,7 +12,7 @@ type Props = {
 };
 
 export function ClutchWonPercentageChart({ axis }: Props) {
-  const { chartsData, matches } = usePlayer();
+  const { chartsData } = usePlayer();
   const { t } = useLingui();
   const data: [string, number][] = buildAveragePlayerChartData({
     field: 'clutchWonPercentage',
@@ -54,7 +54,6 @@ export function ClutchWonPercentageChart({ axis }: Props) {
   useOpenMatchOnPointDoubleClick({
     axis,
     chartsData,
-    matches,
     getChartInstance,
   });
 

--- a/src/ui/player/charts/headshot-percentage-chart.tsx
+++ b/src/ui/player/charts/headshot-percentage-chart.tsx
@@ -13,7 +13,7 @@ type Props = {
 };
 
 export function HeadshotPercentageChart({ axis }: Props) {
-  const { chartsData, matches } = usePlayer();
+  const { chartsData } = usePlayer();
   const { t } = useLingui();
   const data: [string, number][] = buildAveragePlayerChartData({
     field: 'headshotPercentage',
@@ -55,7 +55,6 @@ export function HeadshotPercentageChart({ axis }: Props) {
   useOpenMatchOnPointDoubleClick({
     axis,
     chartsData,
-    matches,
     getChartInstance,
   });
 

--- a/src/ui/player/charts/kill-death-ratio-chart.tsx
+++ b/src/ui/player/charts/kill-death-ratio-chart.tsx
@@ -13,7 +13,7 @@ type Props = {
 };
 
 export function KillDeathRatioChart({ axis }: Props) {
-  const { chartsData, matches } = usePlayer();
+  const { chartsData } = usePlayer();
   const { t } = useLingui();
   const data: [string, number][] = buildAveragePlayerChartData({
     field: 'killDeathRatio',
@@ -55,7 +55,6 @@ export function KillDeathRatioChart({ axis }: Props) {
   useOpenMatchOnPointDoubleClick({
     axis,
     chartsData,
-    matches,
     getChartInstance,
   });
 

--- a/src/ui/player/charts/match-count-chart.tsx
+++ b/src/ui/player/charts/match-count-chart.tsx
@@ -60,7 +60,7 @@ function buildChartData({ chartsData, axis }: { chartsData: PlayerChartsData[]; 
 }
 
 export function MatchCountChart({ axis }: Props) {
-  const { chartsData, matches } = usePlayer();
+  const { chartsData } = usePlayer();
   const { t } = useLingui();
   const data = buildChartData({ chartsData, axis });
 
@@ -99,7 +99,6 @@ export function MatchCountChart({ axis }: Props) {
   useOpenMatchOnPointDoubleClick({
     axis,
     chartsData,
-    matches,
     getChartInstance,
   });
 

--- a/src/ui/player/charts/use-open-match-on-point-double-click.ts
+++ b/src/ui/player/charts/use-open-match-on-point-double-click.ts
@@ -1,8 +1,7 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { useNavigateToMatch } from 'csdm/ui/hooks/use-navigate-to-match';
 import type { Axis } from './x-axis';
 import type { PlayerChartsData } from 'csdm/common/types/charts/player-charts-data';
-import type { MatchTable } from 'csdm/common/types/match-table';
 import type { ECharts } from 'echarts';
 
 // Navigate to a match when double-clicking a point on a chart
@@ -10,22 +9,13 @@ import type { ECharts } from 'echarts';
 export function useOpenMatchOnPointDoubleClick({
   axis,
   chartsData,
-  matches,
   getChartInstance,
 }: {
   axis: Axis;
   chartsData: PlayerChartsData[];
-  matches: MatchTable[];
   getChartInstance: () => ECharts;
 }) {
   const navigateToMatch = useNavigateToMatch();
-  const checksumPerDate = useMemo(() => {
-    const map: Record<string, string> = {};
-    for (const match of matches) {
-      map[match.date] = match.checksum;
-    }
-    return map;
-  }, [matches]);
 
   useEffect(() => {
     if (axis !== 'match') {
@@ -34,17 +24,13 @@ export function useOpenMatchOnPointDoubleClick({
     const chart = getChartInstance();
     const onDoubleClick = ({ dataIndex }: { dataIndex: number }) => {
       const chartData = chartsData[dataIndex];
-      if (!chartData) {
-        return;
-      }
-      const checksum = checksumPerDate[chartData.matchDate];
-      if (checksum !== undefined) {
-        navigateToMatch(checksum);
+      if (chartData?.matchChecksum !== undefined) {
+        navigateToMatch(chartData.matchChecksum);
       }
     };
     chart.on('dblclick', onDoubleClick);
     return () => {
       chart.off('dblclick', onDoubleClick);
     };
-  }, [axis, chartsData, checksumPerDate, navigateToMatch, getChartInstance]);
+  }, [axis, chartsData, navigateToMatch, getChartInstance]);
 }


### PR DESCRIPTION
## Summary
- use match checksum in player chart data to support double-click navigation across timezones
- remove match date lookup in favor of direct checksum comparisons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5ce30d864832b8601aa1851c1dc6a